### PR TITLE
fix: kibo link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Visualize your AI workflows. Tersa is an open source canvas for building AI work
 - [TipTap](https://tiptap.dev/) for rich text editing
 - [Drizzle ORM](https://orm.drizzle.team/) for database queries
 - [Tailwind CSS](https://tailwindcss.com/) for styling
-- [shadcn/ui](https://ui.shadcn.com/), [Kibo UI](https://www.kibo-ui.com/\) and [Radix UI](https://www.radix-ui.com/) for accessible UI components
+- [shadcn/ui](https://ui.shadcn.com/), [Kibo UI](https://www.kibo-ui.com/) and [Radix UI](https://www.radix-ui.com/) for accessible UI components
 
 ## Getting Started
 


### PR DESCRIPTION
## Description

Very minor fix to make this:
<img width="693" alt="image" src="https://github.com/user-attachments/assets/a7e932f5-f662-4539-95ee-507e18732b49" />

... this instead:
<img width="476" alt="image" src="https://github.com/user-attachments/assets/960fe8e3-1f16-4e1f-a949-7a3e02e001ef" />