### PR TITLE
fix: prevent double-click event propagation from Controls and Toolbar

### DIFF
--- a/components/controls.tsx
+++ b/components/controls.tsx
@@ -5,13 +5,15 @@ import { memo } from "react";
 import { ThemeSwitcher } from "./theme-switcher";
 
 export const ControlsInner = () => (
-  <FlowControls
-    className="flex-col! rounded-full border bg-card/90 p-1 shadow-none! drop-shadow-xs backdrop-blur-sm sm:flex-row!"
-    orientation="horizontal"
-    showInteractive={false}
-  >
-    <ThemeSwitcher />
-  </FlowControls>
+  <div onDoubleClick={(e) => e.stopPropagation()}>
+    <FlowControls
+      className="flex-col! rounded-full border bg-card/90 p-1 shadow-none! drop-shadow-xs backdrop-blur-sm sm:flex-row!"
+      orientation="horizontal"
+      showInteractive={false}
+    >
+      <ThemeSwitcher />
+    </FlowControls>
+  </div>
 );
 
 export const Controls = memo(ControlsInner);

--- a/components/toolbar.tsx
+++ b/components/toolbar.tsx
@@ -36,6 +36,7 @@ export const ToolbarInner = () => {
   return (
     <Panel
       className="m-4 flex items-center rounded-full border bg-card/90 p-1 drop-shadow-xs backdrop-blur-sm"
+      onDoubleClick={(e) => e.stopPropagation()}
       position="bottom-center"
     >
       {nodeButtons.map((button) => (


### PR DESCRIPTION
# Pull Request Description

## Problem

When double-clicking on the viewport controls UI (`Controls`) or the element creation UI (`Toolbar`) at the bottom of the screen, the double-click event propagates to ReactFlow's `onDoubleClick` handler, causing unintended behavior on the canvas (matrix).

## Solution

Added inline `onDoubleClick` handlers to both components that call `event.stopPropagation()` to prevent event propagation. This is a minimal change that solves the issue without affecting other functionality.

## Changes

### Modified Files

- **`components/controls.tsx`**: Wrapped `FlowControls` in a `div` with an inline `onDoubleClick` handler since `FlowControls` doesn't support the `onDoubleClick` prop directly.
- **`components/toolbar.tsx`**: Added an inline `onDoubleClick` handler to the `Panel` component.

### Code Changes

**components/controls.tsx:**
```tsx
// Before
export const ControlsInner = () => (
  <FlowControls
    className="..."
    orientation="horizontal"
    showInteractive={false}
  >
    <ThemeSwitcher />
  </FlowControls>
);

// After
export const ControlsInner = () => (
  <div onDoubleClick={(e) => e.stopPropagation()}>
    <FlowControls
      className="..."
      orientation="horizontal"
      showInteractive={false}
    >
      <ThemeSwitcher />
    </FlowControls>
  </div>
);
```

**components/toolbar.tsx:**
```tsx
// Before
<Panel
  className="..."
  position="bottom-center"
>

// After
<Panel
  className="..."
  onDoubleClick={(e) => e.stopPropagation()}
  position="bottom-center"
>
```

## Testing

Tested locally with the following steps:

1. Started the development server: `pnpm dev`
2. Navigated to a project page
3. Double-clicked on the viewport controls UI (Controls)
4. Double-clicked on the element creation UI (Toolbar)
5. Verified that the double-click event does not propagate to the canvas

## Code Style

- [x] Follows existing code style and conventions
- [x] Minimal changes to solve the issue
- [x] No breaking changes
